### PR TITLE
Add LIBWRAP patch as it is in FreeBSD 14 now.

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -129,6 +129,13 @@
 #include "srclimit.h"
 #include "dh.h"
 
+#ifdef LIBWRAP
+#include <tcpd.h>
+#include <syslog.h>
+extern int allow_severity;
+extern int deny_severity;
+#endif /* LIBWRAP */
+
 /* Re-exec fds */
 #define REEXEC_DEVCRYPTO_RESERVED_FD	(STDERR_FILENO + 1)
 #define REEXEC_STARTUP_PIPE_FD		(STDERR_FILENO + 2)
@@ -1145,6 +1152,12 @@ server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 	pid_t pid;
 	u_char rnd[256];
 	sigset_t nsigset, osigset;
+#ifdef LIBWRAP
+	struct request_info req;
+
+	request_init(&req, RQ_DAEMON, __progname, 0);
+#endif
+
 
 	/* pipes connected to unauthenticated child sshd processes */
 	startup_pipes = xcalloc(options.max_startups, sizeof(int));
@@ -1265,6 +1278,31 @@ server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 					usleep(100 * 1000);
 				continue;
 			}
+#ifdef LIBWRAP
+			/* Check whether logins are denied from this host. */
+			request_set(&req, RQ_FILE, *newsock,
+			    RQ_CLIENT_NAME, "", RQ_CLIENT_ADDR, "", 0);
+			sock_host(&req);
+			if (!hosts_access(&req)) {
+				const struct linger l = { .l_onoff = 1,
+				    .l_linger  = 0 };
+
+				(void )setsockopt(*newsock, SOL_SOCKET,
+				    SO_LINGER, &l, sizeof(l));
+				(void )close(*newsock);
+				/*
+				 * Mimic message from libwrap's refuse()
+				 * exactly.  sshguard, and supposedly lots
+				 * of custom made scripts rely on it.
+				 */
+				syslog(deny_severity,
+				    "refused connect from %s (%s)",
+				    eval_client(&req),
+				    eval_hostaddr(req.client));
+				debug("Connection refused by tcp wrapper");
+				continue;
+			}
+#endif /* LIBWRAP */
 			if (unset_nonblock(*newsock) == -1 ||
 			    pipe(startup_p) == -1) {
 				close(*newsock);
@@ -2036,6 +2074,14 @@ main(int ac, char **av)
 	/* Reinitialize the log (because of the fork above). */
 	log_init(__progname, options.log_level, options.log_facility, log_stderr);
 
+#ifdef LIBWRAP
+	/*
+	 * We log refusals ourselves.  However, libwrap will report
+	 * syntax errors in hosts.allow via syslog(3).
+	 */
+	allow_severity = options.log_facility|LOG_INFO;
+	deny_severity = options.log_facility|LOG_WARNING;
+#endif
 	/*
 	 * Chdir to the root directory so that the current disk can be
 	 * unmounted if desired.


### PR DESCRIPTION
The wrapping is performed immediately after accepting a connection.

Cherry-picked manually from ca573c9a1779bdeeea6d0a6e948676555977737e.